### PR TITLE
Update to latest image and remove `wget` and `unzip` where possible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,5 @@ COPY /src/main/liberty/config/jvmbx.options /config/jvm.options
 # Liberty document reference : https://hub.docker.com/_/websphere-liberty/
 USER root
 RUN chmod g+w /config/apps
-USER 1001
 RUN configure.sh
+USER 1001

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,14 +9,4 @@ COPY /src/main/liberty/config/jvmbx.options /config/jvm.options
 USER root
 RUN chmod g+w /config/apps
 USER 1001
-# install any missing features required by server config
-RUN installUtility install --acceptLicense defaultServer
-
-# Upgrade to production license if URL to JAR provided
-ARG LICENSE_JAR_URL
-RUN \ 
-  if [ $LICENSE_JAR_URL ]; then \
-    wget $LICENSE_JAR_URL -O /tmp/license.jar \
-    && java -jar /tmp/license.jar -acceptLicense /opt/ibm \
-    && rm /tmp/license.jar; \
-  fi
+RUN configure.sh

--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -2,10 +2,6 @@ ENV JAVA_VERSION_PREFIX 1.8.0
 ENV HOME /home/default
 
 USER root
-RUN apt update
-RUN apt install -y wget unzip
-RUN rm -rf /var/lib/apt/lists
-USER 1001
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
@@ -59,6 +55,8 @@ RUN set -eux; \
     apt-get purge --auto-remove -y unzip; \
     apt-get purge --auto-remove -y wget; \
     rm -rf /var/lib/apt/lists/*;
+
+USER 1001
 
 RUN mkdir -m 777 -p /config/resources
 

--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -30,6 +30,9 @@ RUN set -eux; \
          exit 1; \
          ;; \
     esac; \
+    apt-get update \
+    && apt-get install -y --no-install-recommends unzip wget openssl \
+    && rm -rf /var/lib/apt/lists/*; \
     BASE_URL="https://public.dhe.ibm.com/ibmdl/export/pub/systems/cloud/runtimes/java/meta/"; \
     wget -q -U UA_IBM_JAVA_Docker -O /tmp/index.yml ${BASE_URL}/${YML_FILE}; \
     ESUM=$(cat /tmp/index.yml | sed -n '/'${JAVA_VERSION_PREFIX}'/{n;n;p}' | sed -n 's/\s*sha256sum:\s//p' | tr -d '\r' | tail -1); \
@@ -46,14 +49,16 @@ RUN set -eux; \
     rm -f /tmp/index.yml; \
     rm -f /tmp/ibm-java.bin; \
     cd $HOME/java/jre/lib; \
-    rm -rf icc;
-
-RUN mkdir -p $HOME/mvn &&\
+    rm -rf icc; \
+    mkdir -p $HOME/mvn &&\
     MAVEN_VERSION=$(wget -qO- https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/maven-metadata.xml | sed -n 's/\s*<release>\(.*\)<.*>/\1/p') &&\
     wget -q -U UA_IBM_JAVA_Docker -O $HOME/mvn/apache-maven-${MAVEN_VERSION}-bin.tar.gz https://search.maven.org/remotecontent?filepath=org/apache/maven/apache-maven/${MAVEN_VERSION}/apache-maven-${MAVEN_VERSION}-bin.tar.gz &&\
     tar xf $HOME/mvn/apache-maven-${MAVEN_VERSION}-bin.tar.gz -C $HOME/mvn &&\
     mv $HOME/mvn/apache-maven-${MAVEN_VERSION} $HOME/mvn/apache-maven &&\
-    rm -f $HOME/mvn/apache-maven-${MAVEN_VERSION}-bin.tar.gz;
+    rm -f $HOME/mvn/apache-maven-${MAVEN_VERSION}-bin.tar.gz; \
+    apt-get purge --auto-remove -y unzip; \
+    apt-get purge --auto-remove -y wget; \
+    rm -rf /var/lib/apt/lists/*;
 
 RUN mkdir -m 777 -p /config/resources
 


### PR DESCRIPTION
This PR resolves https://github.ibm.com/dev-ex/portal/issues/956, but **cannot be merged before** https://github.ibm.com/dev-ex/tempest/pull/246, as we need to update those scripts to also not use `unzip`.